### PR TITLE
ci(workflows): use go-version-file and add govulncheck

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.x
+          go-version-file: 'go.mod'
   
       - name: coverage
         id: coverage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24'
+          go-version-file: 'go.mod'
+
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -18,7 +18,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>=1.24'
+          go-version-file: 'go.mod'
+
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v3.0.0
         with:

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -1,0 +1,34 @@
+name: Vulnerability Scan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '0 2 1 * *'  # Run at 2 AM on the 1st of every month
+  workflow_dispatch:     # Allow manual triggering
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  vulnerability-scan:
+    runs-on: ubuntu-latest
+    name: Run govulncheck
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          go-package: ./...


### PR DESCRIPTION
- Replace hardcoded go-version with go-version-file: 'go.mod'
  in coverage, release, and snapshot workflows
- Add vulnerability-scan.yml running govulncheck on push,
  PR, and monthly schedule

Refs #65